### PR TITLE
Add into_bits convenience method for UperReader

### DIFF
--- a/src/syn/io/uper.rs
+++ b/src/syn/io/uper.rs
@@ -752,6 +752,11 @@ impl<'a> From<(&'a [u8], usize)> for UperReader<Bits<'a>> {
 
 impl<B: ScopedBitRead> UperReader<B> {
     #[inline]
+    pub fn into_bits(self) -> B {
+        self.bits
+    }
+
+    #[inline]
     fn read_length_determinant(
         &mut self,
         lower_bound: Option<u64>,


### PR DESCRIPTION
`UperReader`s can be created from any type implementing `ScopedBitRead`. However, `UperReader::from` obviously consumes this type.  Users of `UperReader` may want to get the original `ScopedBitReader` back out after they are done with the `UperReader`.  This patch provides an `into_bits` function which returns the underlying `ScopedBitRead` type, consuming the `UperReader`.