### PR TITLE
Derive `Clone` for `UperReader`

### DIFF
--- a/src/syn/io/uper.rs
+++ b/src/syn/io/uper.rs
@@ -726,6 +726,7 @@ impl Writer for UperWriter {
     }
 }
 
+#[derive(Clone)]
 pub struct UperReader<B: ScopedBitRead> {
     bits: B,
     scope: Option<Scope>,


### PR DESCRIPTION
Auto-derive Clone for `UperReader`.  This is particularly useful for implementors of the `ScopedBitRead` trait who also implement `Clone`, allowing them to then clone their `UperReader` type.